### PR TITLE
Incremental loading from succinct data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proskomma-core",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "A Scripture Runtime Engine",
   "files": [
     "dist"


### PR DESCRIPTION
This PR adds an optional `bookCodes` argument to `loadSuccinctDocSet()` as well as a new `augmentSuccinctDocSet()` method. Used together they enable just-in-time loading. There's a simple test in `serialize`. All tests pass.